### PR TITLE
Add optional IsRichHtml property to create ticket class

### DIFF
--- a/src/Api/Entity/Ticket/CreateTicket.php
+++ b/src/Api/Entity/Ticket/CreateTicket.php
@@ -33,6 +33,7 @@ class CreateTicket
         protected readonly ?int $articleId = null,
         protected readonly ?int $articleShortcutId = null,
         protected readonly array $customAttributes = [],
+        protected readonly ?bool $isRichHtml = false,
     ) {
         //
     }
@@ -66,6 +67,7 @@ class CreateTicket
             'ArticleID' => $this->articleId,
             'ArticleShortcutID' => $this->articleShortcutId,
             'CustomAttributes' => $this->customAttributes,
+            'IsRichHtml' => $this->isRichHtml,
         ];
     }
 }


### PR DESCRIPTION
## Overview ##
The TDX Ticket endpoint has an optional boolean parameter to specify whether the ticket contains rich-text or plain-text, which is not currently part of the `CreateTicket.php` class. This PR adds the `isRichHtml` as an optional parameter that is defaulted to false.

If this is enabled, it allows tickets created through the API to contain HTML formatting, which is available through the web editor. The benefit of this is allowing for API-created tickets to format tables, layouts, and more varied styling. 