### PR TITLE
Add ticket update/feed entry creation endpoint functionality

### DIFF
--- a/src/Api/Client/Ticket/Ticket.php
+++ b/src/Api/Client/Ticket/Ticket.php
@@ -59,7 +59,7 @@ class Ticket extends TdxClient
     public function update(int $ticketId, TicketFeedEntry $feedEntry): TicketFeedEntryResponse
     {
         $response = $this->post(
-            path: sprintf('/api/%s/tickets/%s/sla', $this->tdxApplication->id, $ticketId),
+            path: sprintf('/api/%s/tickets/%s/feed', $this->tdxApplication->id, $ticketId),
             payload: $feedEntry->toArray()
         );
 

--- a/src/Api/Client/Ticket/Ticket.php
+++ b/src/Api/Client/Ticket/Ticket.php
@@ -9,6 +9,8 @@ use Northwestern\Sysdev\TeamDynamix\Api\Client\TdxClient;
 use Northwestern\Sysdev\TeamDynamix\Api\Entity\General\Application;
 use Northwestern\Sysdev\TeamDynamix\Api\Entity\Response;
 use Northwestern\Sysdev\TeamDynamix\Api\Entity\Ticket\CreateTicket;
+use Northwestern\Sysdev\TeamDynamix\Api\Entity\Ticket\FeedEntry\TicketFeedEntry;
+use Northwestern\Sysdev\TeamDynamix\Api\Entity\Ticket\FeedEntry\TicketFeedEntryResponse;
 use Northwestern\Sysdev\TeamDynamix\Api\Entity\Ticket\TicketResponse;
 
 class Ticket extends TdxClient
@@ -49,6 +51,19 @@ class Ticket extends TdxClient
         );
 
         return TicketResponse::fromResponse($response);
+    }
+
+    /**
+     * @link https://solutions.teamdynamix.com/TDWebApi/Home/section/Tickets#POSTapi/{appId}/tickets/{id}/feed
+     */
+    public function update(int $ticketId, TicketFeedEntry $feedEntry): TicketFeedEntryResponse
+    {
+        $response = $this->post(
+            path: sprintf('/api/%s/tickets/%s/sla', $this->tdxApplication->id, $ticketId),
+            payload: $feedEntry->toArray()
+        );
+
+        return TicketFeedEntryResponse::fromResponse($response);
     }
 
     /**

--- a/src/Api/Entity/Ticket/FeedEntry/TicketFeedEntry.php
+++ b/src/Api/Entity/Ticket/FeedEntry/TicketFeedEntry.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Northwestern\Sysdev\TeamDynamix\Api\Entity\Ticket\FeedEntry;
+
+class TicketFeedEntry
+{
+    public function __construct(
+        protected readonly string $comments,
+        protected readonly bool $cascadeStatus = false,
+        protected readonly bool $isPrivate = false,
+        protected readonly ?int $newStatusId = null,
+        protected readonly ?array $notify = null,
+        protected readonly ?bool $isRichHtml = false,
+    ) {
+        //
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'Comments' => $this->comments,
+            'CascadeStatus' => $this->cascadeStatus,
+            'IsPrivate' => $this->isPrivate,
+            'NewStatusID' => $this->newStatusId,
+            'Notify' => $this->notify,
+            'IsRichHtml' => $this->isRichHtml
+        ];
+    }
+
+    public static function fromArray(array $data): ?self
+    {
+        return new self(
+            comments: $data['Comments'],
+            cascadeStatus: $data['CascadeStatus'],
+            isPrivate: $data['IsPrivate'],
+            newStatusId: $data['NewStatusID'],
+            notify: $data['Notify'],
+            isRichHtml: $data['IsRichHtml'],
+        );
+    }
+}

--- a/src/Api/Entity/Ticket/FeedEntry/TicketFeedEntryResponse.php
+++ b/src/Api/Entity/Ticket/FeedEntry/TicketFeedEntryResponse.php
@@ -11,13 +11,12 @@ class TicketFeedEntryResponse
     {
         $feedEntryData = json_decode($response->body, true);
 
-        return new self($response->url, $response->rateLimit, $feedEntryData['ID'], $feedEntryData );
+        return new self($response->url, $response->rateLimit, $feedEntryData );
     }
 
     public function __construct(
         public readonly string $url,
         public readonly RateLimit $rateLimit,
-        public readonly int $id,
         public readonly array $data,
     )
     {

--- a/src/Api/Entity/Ticket/FeedEntry/TicketFeedEntryResponse.php
+++ b/src/Api/Entity/Ticket/FeedEntry/TicketFeedEntryResponse.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Northwestern\Sysdev\TeamDynamix\Api\Entity\Ticket\FeedEntry;
+
+use Northwestern\Sysdev\TeamDynamix\Api\Entity\RateLimit;
+use Northwestern\Sysdev\TeamDynamix\Api\Entity\Response;
+
+class TicketFeedEntryResponse
+{
+    public static function fromResponse(Response $response): self
+    {
+        $feedEntryData = json_decode($response->body, true);
+
+        return new self($response->url, $response->rateLimit, $feedEntryData['ID'], $feedEntryData );
+    }
+
+    public function __construct(
+        public readonly string $url,
+        public readonly RateLimit $rateLimit,
+        public readonly int $id,
+        public readonly array $data,
+    )
+    {
+        //
+    }
+}


### PR DESCRIPTION
### Overview

As part of competitive applications project, a requirement for a new feature was to have the SOAP platform be able to close tickets automatically if the issue resolves itself before the ticket is manually closed or investigated further. As such, this PR covers the addition of the [`Updates a ticket`](https://solutions.teamdynamix.com/TDWebApi/Home/section/Tickets#POSTapi/{appId}/tickets/{id}/feed) endpoint. 

The post request sent to TDX posts a comment and optionally updates the status of the ticket. If no status is included in the update post request, then the ticket's status will not be changed. The current list of statuses is below:

| **Status ID** | **Status Description** |
|---------------|------------------------|
| 77            | New                    |
| 78            | Open                   |
| 79            | In Progress            |
| 80            | Resolved/Completed     |
| 81            | Closed                 |
| 82            | Cancelled              |
| 83            | Pending                |